### PR TITLE
Fixed an Xcode 4.5 warning

### DIFF
--- a/DMTabBar/DMTabBar/DMTabBarItem.m
+++ b/DMTabBar/DMTabBar/DMTabBarItem.m
@@ -55,7 +55,7 @@ static CGFloat kDMTabBarItemGradientColor_Locations[] =     {0.0f, 0.5f, 1.0f};
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"[DMTabBarItem] tag=%i - title=%@", self.tag,self.title];
+    return [NSString stringWithFormat:@"[DMTabBarItem] tag=%i - title=%@", (int)self.tag,self.title];
 }
 
 #pragma mark - Properties redirects


### PR DESCRIPTION
Xcode 4.5 complains if you use a %d together with an NSInteger.
