### PR TITLE
Gradient start / end color, and border color, made a public property and thus configurable.

### DIFF
--- a/DMTabBar/DMTabBar/DMTabBar.h
+++ b/DMTabBar/DMTabBar/DMTabBar.h
@@ -33,6 +33,9 @@ typedef void (^DMTabBarEventsHandler)(DMTabBarItemSelectionType selectionType, D
 // change selected item by passing a new index { 0 < index < tabBarItems.count }
 @property (nonatomic,assign) NSUInteger         selectedIndex;
 
+@property (nonatomic,strong) NSColor *gradientColorStart;
+@property (nonatomic,strong) NSColor *gradientColorEnd;
+@property (nonatomic,strong) NSColor *borderColor;
 
 // Handle selection change events using blocks
 - (void) handleTabBarItemSelection:(DMTabBarEventsHandler) selectionHandler;

--- a/DMTabBar/DMTabBar/DMTabBar.m
+++ b/DMTabBar/DMTabBar/DMTabBar.m
@@ -13,8 +13,7 @@
 // (Colors and gradient from Stephan Michels Softwareentwicklung und Beratung - SMTabBar)
 #define kDMTabBarGradientColor_Start                        [NSColor colorWithCalibratedRed:0.851f green:0.851f blue:0.851f alpha:1.0f]
 #define kDMTabBarGradientColor_End                          [NSColor colorWithCalibratedRed:0.700f green:0.700f blue:0.700f alpha:1.0f]
-#define KDMTabBarGradient                                   [[NSGradient alloc] initWithStartingColor: kDMTabBarGradientColor_Start \
-                                                                                          endingColor: kDMTabBarGradientColor_End]
+#define KDMTabBarGradient                                   
 
 // Border color of the bar
 #define kDMTabBarBorderColor                                [NSColor colorWithDeviceWhite:0.2 alpha:1.0f]
@@ -42,12 +41,38 @@
 @synthesize selectedIndex,selectedTabBarItem;
 @synthesize tabBarItems;
 
+- (id)initWithFrame:(NSRect)frameRect
+{
+    if (self = [super initWithFrame:frameRect])
+    {
+        [self setDefaultColors];
+    }
+    
+    return self;
+}
+
+- (id)initWithCoder:(NSCoder *)aDecoder
+{
+    if (self = [super initWithCoder:aDecoder])
+    {
+        [self setDefaultColors];
+    }
+    return self;
+}
+
+- (void)setDefaultColors
+{
+    self.gradientColorStart = kDMTabBarGradientColor_Start;
+    self.gradientColorEnd = kDMTabBarGradientColor_End;
+    self.borderColor = kDMTabBarBorderColor;
+}
+
 - (void)drawRect:(NSRect)dirtyRect {
     // Draw bar gradient
-    [KDMTabBarGradient drawInRect:self.bounds angle:90.0];
+    [[[NSGradient alloc] initWithStartingColor:self.gradientColorStart endingColor:self.gradientColorEnd] drawInRect:self.bounds angle:90.0];
     
     // Draw drak gray bottom border
-    [kDMTabBarBorderColor setStroke];
+    [_borderColor setStroke];
     [NSBezierPath setDefaultLineWidth:0.0f];
     [NSBezierPath strokeLineFromPoint:NSMakePoint(NSMinX(self.bounds), NSMaxY(self.bounds)) 
                               toPoint:NSMakePoint(NSMaxX(self.bounds), NSMaxY(self.bounds))];


### PR DESCRIPTION
Gradient start / end color, and border color, made a public property and thus configurable.. Should handle both programmatic initialisation and Nib loading (-initWithCoder:) of DMTabBar.
